### PR TITLE
Add text progress column and compact SEO status view

### DIFF
--- a/src/Support/TextProgressPresenter.php
+++ b/src/Support/TextProgressPresenter.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Backpack\Helpers\Support;
+
+class TextProgressPresenter
+{
+    public static function prepare($entry, array $column): array
+    {
+        $defaultLocale = $column['locale'] ?? app()->getLocale();
+        $attribute = $column['attribute'] ?? $column['name'] ?? null;
+        $emptyText = $column['empty_text'] ?? __('Не заполнено');
+        $availableLocales = self::resolveLocales($column['locales'] ?? null, $defaultLocale);
+        $totalLocales = max(count($availableLocales), 1);
+        $translations = self::collectTranslations($entry, $attribute, $availableLocales, $defaultLocale);
+        $displayLocale = $column['display_locale'] ?? $defaultLocale;
+
+        $badges = [];
+        $filledLocales = 0;
+
+        foreach ($availableLocales as $locale) {
+            $value = $translations[$locale] ?? '';
+            $stringValue = self::stringify($value);
+            $isFilled = $stringValue !== '';
+
+            if ($isFilled) {
+                $filledLocales++;
+            }
+
+            $badges[] = [
+                'code' => self::formatLocaleCode($locale),
+                'filled' => $isFilled,
+            ];
+        }
+
+        $displayValue = self::determineDisplayValue($translations, $displayLocale, $defaultLocale);
+
+        $summary = $filledLocales === 0
+            ? $emptyText
+            : sprintf('%d из %d заполнено', $filledLocales, $totalLocales);
+
+        $summaryClass = $filledLocales === 0 ? 'text-warning' : 'text-muted';
+        $progressPercent = $totalLocales > 0
+            ? round(($filledLocales / $totalLocales) * 100)
+            : 0;
+
+        return [
+            'text' => $displayValue,
+            'translations' => $translations,
+            'summary' => $summary,
+            'summary_class' => $summaryClass,
+            'badges' => $badges,
+            'progress_percent' => $progressPercent,
+            'filled_locales' => $filledLocales,
+            'total_locales' => $totalLocales,
+            'empty_text' => $emptyText,
+        ];
+    }
+
+    protected static function resolveLocales($configured, ?string $defaultLocale): array
+    {
+        $configured = (array) ($configured ?? config('backpack.crud.locales', []));
+        $locales = \Illuminate\Support\Arr::isAssoc($configured)
+            ? array_keys($configured)
+            : array_values($configured);
+
+        $locales = array_values(array_filter(array_unique(array_map('strval', $locales))));
+
+        if ($locales === [] && $defaultLocale) {
+            $locales[] = (string) $defaultLocale;
+        }
+
+        if ($locales === []) {
+            $locales[] = app()->getLocale();
+        }
+
+        return array_values(array_filter($locales));
+    }
+
+    protected static function collectTranslations($entry, ?string $attribute, array $locales, ?string $fallbackLocale): array
+    {
+        $translations = [];
+
+        if ($attribute === null) {
+            return $translations;
+        }
+
+        if (
+            method_exists($entry, 'isTranslatableAttribute')
+            && method_exists($entry, 'getTranslations')
+            && $entry->isTranslatableAttribute($attribute)
+        ) {
+            $translations = (array) $entry->getTranslations($attribute);
+        } else {
+            $value = data_get($entry, $attribute);
+            foreach ($locales as $locale) {
+                $translations[$locale] = $value;
+            }
+        }
+
+        if (
+            $translations === []
+            && $fallbackLocale
+            && method_exists($entry, 'isTranslatableAttribute')
+            && method_exists($entry, 'getTranslation')
+            && $entry->isTranslatableAttribute($attribute)
+        ) {
+            $fallback = $entry->getTranslation($attribute, $fallbackLocale);
+            if ($fallback !== null) {
+                $translations[$fallbackLocale] = $fallback;
+            }
+        }
+
+        return $translations;
+    }
+
+    protected static function determineDisplayValue(array $translations, ?string $displayLocale, ?string $defaultLocale): string
+    {
+        $localesToCheck = array_filter([
+            $displayLocale,
+            $defaultLocale,
+        ]);
+
+        foreach ($localesToCheck as $locale) {
+            $value = $translations[$locale] ?? null;
+            $stringValue = self::stringify($value);
+            if ($stringValue !== '') {
+                return $stringValue;
+            }
+        }
+
+        foreach ($translations as $value) {
+            $stringValue = self::stringify($value);
+            if ($stringValue !== '') {
+                return $stringValue;
+            }
+        }
+
+        return '';
+    }
+
+    protected static function stringify($value): string
+    {
+        if (is_array($value)) {
+            $value = json_encode($value, JSON_UNESCAPED_UNICODE);
+        }
+
+        return is_scalar($value) ? trim((string) $value) : '';
+    }
+
+    protected static function formatLocaleCode(string $value): string
+    {
+        if (function_exists('mb_strtoupper')) {
+            return mb_strtoupper((string) $value);
+        }
+
+        return strtoupper((string) $value);
+    }
+}

--- a/src/resources/views/vendor/backpack/crud/columns/partials/translation_progress_styles.blade.php
+++ b/src/resources/views/vendor/backpack/crud/columns/partials/translation_progress_styles.blade.php
@@ -1,0 +1,44 @@
+@once
+    @push('crud_list_styles')
+        <style>
+            .translation-progress-meta {
+                font-size: 11px;
+                letter-spacing: 0.03em;
+            }
+
+            .translation-progress-summary {
+                text-transform: none;
+            }
+
+            .translation-locale-tags {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 0.25rem;
+            }
+
+            .translation-locale-tags--compact {
+                justify-content: flex-end;
+            }
+
+            .translation-locale-tags--spaced {
+                justify-content: space-between;
+                width: 100%;
+            }
+
+            .translation-locale-tag {
+                font-size: 6px;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+                color: #adb5bd;
+            }
+
+            .translation-locale-tag.is-filled {
+                color: #28a745;
+            }
+
+            .translation-progress-bar {
+                height: 3px;
+            }
+        </style>
+    @endpush
+@endonce

--- a/src/resources/views/vendor/backpack/crud/columns/seo_status_linear.blade.php
+++ b/src/resources/views/vendor/backpack/crud/columns/seo_status_linear.blade.php
@@ -1,0 +1,31 @@
+@php
+    $presentation = \Backpack\Helpers\Support\SeoStatusPresenter::prepare($entry, $column);
+@endphp
+
+@if (! $presentation['has_rows'])
+    <span class="text-muted">—</span>
+@else
+    @include('crud::columns.partials.translation_progress_styles')
+    <div class="seo-status-linear d-flex flex-column">
+        @foreach($presentation['rows'] as $row)
+            <div class="seo-status-linear-row rounded mb-1 px-3 py-2 {{ $row['container_class'] }}">
+                <div class="d-flex justify-content-between align-items-center flex-wrap">
+                    <strong class="text-uppercase" style="font-size: 12px; font-weight: 500; letter-spacing: 0.05em;">
+                        {{ $row['label'] }}
+                    </strong>
+                    <small class="{{ $row['summary_class'] }}">{{ $row['summary'] }}</small>
+                </div>
+                <div class="translation-locale-tags translation-locale-tags--spaced mt-2">
+                    @foreach($row['badges'] as $badge)
+                        <span class="translation-locale-tag {{ $badge['filled'] ? 'is-filled' : '' }}">
+                            {{ $badge['code'] }}
+                        </span>
+                    @endforeach
+                </div>
+                <div class="progress translation-progress-bar mt-1">
+                    <div class="progress-bar bg-success" role="progressbar" style="width: {{ $row['progress_percent'] }}%;" aria-valuenow="{{ $row['progress_percent'] }}" aria-valuemin="0" aria-valuemax="100"></div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+@endif

--- a/src/resources/views/vendor/backpack/crud/columns/text_progress.blade.php
+++ b/src/resources/views/vendor/backpack/crud/columns/text_progress.blade.php
@@ -1,0 +1,57 @@
+@php
+    $presentation = \Backpack\Helpers\Support\TextProgressPresenter::prepare($entry, $column);
+    $value = $presentation['text'];
+
+    if (array_key_exists('value', $column)) {
+        $value = $column['value'];
+        if (is_callable($value)) {
+            $value = $value($entry, $column);
+        }
+    }
+
+    if (($value === null || $value === '') && array_key_exists('default', $column)) {
+        $value = $column['default'];
+    }
+
+    $value = is_null($value) ? '' : (string) $value;
+    $value = ($column['prefix'] ?? '') . $value . ($column['suffix'] ?? '');
+    $limit = $column['limit'] ?? null;
+
+    if ($limit !== null) {
+        $end = $column['limit_end'] ?? '...';
+        $value = \Illuminate\Support\Str::limit($value, (int) $limit, $end);
+    }
+
+    $escaped = $column['escaped'] ?? true;
+@endphp
+
+@include('crud::columns.partials.translation_progress_styles')
+
+<div class="translation-text-progress d-flex flex-column">
+    <div class="translation-text-progress-value">
+        @if(trim($value) === '')
+            <span class="text-muted">—</span>
+        @else
+            @if($escaped)
+                {{ $value }}
+            @else
+                {!! $value !!}
+            @endif
+        @endif
+    </div>
+    <div class="translation-progress-meta d-flex justify-content-between align-items-center mt-1">
+        <small class="translation-progress-summary {{ $presentation['summary_class'] }}">
+            {{ $presentation['summary'] }}
+        </small>
+        <div class="translation-locale-tags translation-locale-tags--compact">
+            @foreach($presentation['badges'] as $badge)
+                <span class="translation-locale-tag {{ $badge['filled'] ? 'is-filled' : '' }}">
+                    {{ $badge['code'] }}
+                </span>
+            @endforeach
+        </div>
+    </div>
+    <div class="progress translation-progress-bar mt-1">
+        <div class="progress-bar bg-success" role="progressbar" style="width: {{ $presentation['progress_percent'] }}%;" aria-valuenow="{{ $presentation['progress_percent'] }}" aria-valuemin="0" aria-valuemax="100"></div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add a TextProgressPresenter and a `text_progress` column to render translated content together with progress metadata
- extract shared translation progress styles so locale tags look consistent
- add an inline `seo_status_linear` column variant that keeps the badges above the progress bar for a more compact layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691db69f9fe883308560c0ffaee6195f)